### PR TITLE
chore: updated namespaces and assembly name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chinook.View
+# Nventive.View
 Suite of controls to use with WinUI and Uno Platform
 
 # IMPORTANT NOTE:

--- a/src/View.Uno/Controls/AnimatedContentControl/AnimatedContentControl.cs
+++ b/src/View.Uno/Controls/AnimatedContentControl/AnimatedContentControl.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class AnimatedContentControl : ContentControl
 	{

--- a/src/View.Uno/Controls/AnimatedControl/AnimatedControl.cs
+++ b/src/View.Uno/Controls/AnimatedControl/AnimatedControl.cs
@@ -10,7 +10,7 @@ using Uno.Logging;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[TemplateVisualState(GroupName = AnimationVisualStateGroup, Name = AnimatingVisualState)]
 	[TemplateVisualState(GroupName = AnimationVisualStateGroup, Name = NotAnimatingVisualState)]

--- a/src/View.Uno/Controls/AnimatedHeaderControl/AnimatedHeaderControl.cs
+++ b/src/View.Uno/Controls/AnimatedHeaderControl/AnimatedHeaderControl.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Controls;
 using Microsoft.Extensions.Logging;
 using Uno.Logging;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// A control which wraps a scrolling container (eg, a ScrollViewer or a ListView) and exposes the scrolled offset relative to a defined header height.

--- a/src/View.Uno/Controls/DelayControl/DelayControl.cs
+++ b/src/View.Uno/Controls/DelayControl/DelayControl.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// The goal of the control is to delay view creation.

--- a/src/View.Uno/Controls/DelayControl/DelayControl.xaml
+++ b/src/View.Uno/Controls/DelayControl/DelayControl.xaml
@@ -6,13 +6,9 @@
 					xmlns:xamarin="http://nventive.com/xamarin"
 					xmlns:android="http://nventive.com/android"
 					xmlns:ios="http://nventive.com/ios"
-					xmlns:not_android="http:///umbrella/ui/not_android"
-					xmlns:not_ios="http:///umbrella/ui/not_ios"
-					xmlns:u="using:Chinook.View.Controls"
-					xmlns:uc="using:nVentive.Chinook.Views.Converters"
-					xmlns:cv="using:Parkland.Views.Converters"
+					xmlns:u="using:Nventive.View.Controls"
 					xmlns:uloc="http://nventive.com/localization/1.0"
-					xmlns:ub="using:Chinook.View.Extensions"
+					xmlns:ub="using:Nventive.View.Extensions"
 					mc:Ignorable="d xamarin android ios uloc">
 
 	<!-- This one is for things that should be visible by default. It has a fade in animation. -->

--- a/src/View.Uno/Controls/ImagePresenter/ImagePresenter.Android.cs
+++ b/src/View.Uno/Controls/ImagePresenter/ImagePresenter.Android.cs
@@ -6,7 +6,7 @@ using Android.Animation;
 using Android.Views;
 using Windows.UI.Xaml;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class ImagePresenter
 	{

--- a/src/View.Uno/Controls/ImagePresenter/ImagePresenter.Properties.cs
+++ b/src/View.Uno/Controls/ImagePresenter/ImagePresenter.Properties.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class ImagePresenter : Control
 	{

--- a/src/View.Uno/Controls/ImagePresenter/ImagePresenter.Xamarin.cs
+++ b/src/View.Uno/Controls/ImagePresenter/ImagePresenter.Xamarin.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class ImagePresenter
 	{

--- a/src/View.Uno/Controls/ImagePresenter/ImagePresenter.cs
+++ b/src/View.Uno/Controls/ImagePresenter/ImagePresenter.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[TemplatePart(Name = GridPartName, Type = typeof(Grid))]
 	[TemplatePart(Name = ImageBorderPartName, Type = typeof(Border))]

--- a/src/View.Uno/Controls/ImagePresenter/ImagePresenter.iOS.cs
+++ b/src/View.Uno/Controls/ImagePresenter/ImagePresenter.iOS.cs
@@ -5,7 +5,7 @@ using System.Text;
 using UIKit;
 using Windows.UI.Xaml;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class ImagePresenter
 	{

--- a/src/View.Uno/Controls/ImagePresenter/ImagePresenter.xaml
+++ b/src/View.Uno/Controls/ImagePresenter/ImagePresenter.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:u="using:Chinook.View.Controls"
-					xmlns:converters="using:Chinook.View.Converters">
+					xmlns:u="using:Nventive.View.Controls"
+					xmlns:converters="using:Nventive.View.Converters">
 
 	<!-- NOTE : If you don't need to have CornerRadius or a Circle, please use the style below for a better performance -->
 	<!-- [ Related UserEcho : https://feedback.nventive.com/communities/1/topics/3133-imagepresenter-imagebrush-is-sometimes-deformed ] -->

--- a/src/View.Uno/Controls/ImageSlideshow/ImageSlideshow.Properties.cs
+++ b/src/View.Uno/Controls/ImageSlideshow/ImageSlideshow.Properties.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class ImageSlideshow : Control
 	{

--- a/src/View.Uno/Controls/ImageSlideshow/ImageSlideshow.cs
+++ b/src/View.Uno/Controls/ImageSlideshow/ImageSlideshow.cs
@@ -13,7 +13,7 @@ using Uno.Disposables;
 using Windows.UI.Core;
 using System.Threading.Tasks;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[TemplatePart(Name = "PART_FlipView", Type = typeof(Selector))]
 	[TemplatePart(Name = "PART_ItemsControl", Type = typeof(ItemsControl))]

--- a/src/View.Uno/Controls/ImageSlideshow/ImageSlideshow.xaml
+++ b/src/View.Uno/Controls/ImageSlideshow/ImageSlideshow.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:u="using:Chinook.View.Controls">
+	xmlns:u="using:Nventive.View.Controls">
 
 	<Style x:Key="DefaultImageSlideshowStyle"
 		   TargetType="u:ImageSlideshow">

--- a/src/View.Uno/Controls/LogCounterControl/LogCounterControl.UWP.cs
+++ b/src/View.Uno/Controls/LogCounterControl/LogCounterControl.UWP.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Uno.Disposables;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public sealed partial class LogCounterControl : ContentControl, ILogger
 	{

--- a/src/View.Uno/Controls/LogCounterControl/LogCounterControl.xaml
+++ b/src/View.Uno/Controls/LogCounterControl/LogCounterControl.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:u="using:Chinook.View.Controls"
+    xmlns:u="using:Nventive.View.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     mc:Ignorable="">

--- a/src/View.Uno/Controls/MembershipCardControl/MembershipCardControl.Brightness.cs
+++ b/src/View.Uno/Controls/MembershipCardControl/MembershipCardControl.Brightness.cs
@@ -10,7 +10,7 @@ using Windows.UI.Core;
 using Windows.Foundation.Metadata;
 #endif
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
     public partial class MembershipCardControl
     {

--- a/src/View.Uno/Controls/MembershipCardControl/MembershipCardControl.cs
+++ b/src/View.Uno/Controls/MembershipCardControl/MembershipCardControl.cs
@@ -15,7 +15,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Core;
 using Uno.Disposables;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// Control to display as a popup a membership card when the device is rotated to landscape, in an app which is otherwise locked to portrait.

--- a/src/View.Uno/Controls/MembershipCardControl/MembershipCardControl.xaml
+++ b/src/View.Uno/Controls/MembershipCardControl/MembershipCardControl.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:u="using:Chinook.View.Controls"
+					xmlns:u="using:Nventive.View.Controls"
 					xmlns:uloc="http://nventive.com/localization/1.0"
 					mc:Ignorable="d uloc">
 

--- a/src/View.Uno/Controls/ParallaxListView/ParallaxListView.Properties.cs
+++ b/src/View.Uno/Controls/ParallaxListView/ParallaxListView.Properties.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class ParallaxListView : Control
 	{

--- a/src/View.Uno/Controls/ParallaxListView/ParallaxListView.cs
+++ b/src/View.Uno/Controls/ParallaxListView/ParallaxListView.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Media;
 using Uno.Logging;
 using System.Reactive.Linq;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[TemplatePart(Name = HeaderBackgroundName, Type = typeof(StackPanel))]
 	[TemplatePart(Name = HeaderForegroundName, Type = typeof(StackPanel))]

--- a/src/View.Uno/Controls/ParallaxListView/ParallaxListView.xaml
+++ b/src/View.Uno/Controls/ParallaxListView/ParallaxListView.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:u="using:Chinook.View.Controls"
-					xmlns:ue="using:Chinook.View.Extensions"
+					xmlns:u="using:Nventive.View.Controls"
+					xmlns:ue="using:Nventive.View.Extensions"
 					xmlns:toolkit="using:Uno.UI.Toolkit">
 
 	<Style TargetType="ListViewItem"

--- a/src/View.Uno/Controls/PathControl/PathControl.cs
+++ b/src/View.Uno/Controls/PathControl/PathControl.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// A control which wraps a Path, facilitating animation and allowing binding to the Foreground property (mapped to Path.Fill through styles).

--- a/src/View.Uno/Controls/PathControl/PathControl.xaml
+++ b/src/View.Uno/Controls/PathControl/PathControl.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:u="using:Chinook.View.Controls">
+					xmlns:u="using:Nventive.View.Controls">
 
 	<Style TargetType="u:PathControl"
 		   x:Key="DefaultPathControlStyle">

--- a/src/View.Uno/Controls/PeekingFlipView/PeekingFlipView.cs
+++ b/src/View.Uno/Controls/PeekingFlipView/PeekingFlipView.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[TemplatePart(Name = "ScrollViewer", Type = typeof(ScrollViewer))]
 	public partial class PeekingFlipView : ListView

--- a/src/View.Uno/Controls/PeekingFlipView/PeekingFlipView.xaml
+++ b/src/View.Uno/Controls/PeekingFlipView/PeekingFlipView.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:u="using:Chinook.View.Controls"
+    xmlns:u="using:Nventive.View.Controls"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:xamarin="http://uno.ui/xamarin"
     mc:Ignorable="xamarin">

--- a/src/View.Uno/Controls/PeekingFlipView/PeekingFlipViewItem.cs
+++ b/src/View.Uno/Controls/PeekingFlipView/PeekingFlipViewItem.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class PeekingFlipViewItem : SelectorItem
 	{

--- a/src/View.Uno/Controls/PeekingFlipView/PeekingFlipViewItem.xaml
+++ b/src/View.Uno/Controls/PeekingFlipView/PeekingFlipViewItem.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:u="using:Chinook.View.Controls"
+    xmlns:u="using:Nventive.View.Controls"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:xamarin="http://uno.ui/xamarin"
     mc:Ignorable="xamarin">

--- a/src/View.Uno/Controls/SwipableItem/OnSwipeListener.Android.cs
+++ b/src/View.Uno/Controls/SwipableItem/OnSwipeListener.Android.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 using Uno.UI;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public class OnSwipeListener : Java.Lang.Object, Android.Views.View.IOnTouchListener
 	{

--- a/src/View.Uno/Controls/SwipableItem/PanGestureListener.Android.cs
+++ b/src/View.Uno/Controls/SwipableItem/PanGestureListener.Android.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 using Android.Views;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public class PanGestureListener : GestureDetector.SimpleOnGestureListener
 	{

--- a/src/View.Uno/Controls/SwipableItem/SwipableItem.Android.cs
+++ b/src/View.Uno/Controls/SwipableItem/SwipableItem.Android.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using System.Numerics;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class SwipableItem : ContentControl, Android.Views.View.IOnTouchListener
 	{

--- a/src/View.Uno/Controls/SwipableItem/SwipableItem.Properties.cs
+++ b/src/View.Uno/Controls/SwipableItem/SwipableItem.Properties.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class SwipableItem
 	{

--- a/src/View.Uno/Controls/SwipableItem/SwipableItem.iOS.cs
+++ b/src/View.Uno/Controls/SwipableItem/SwipableItem.iOS.cs
@@ -6,7 +6,7 @@ using UIKit;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class SwipableItem : ContentControl
 	{

--- a/src/View.Uno/Controls/SwipableItem/SwipableItemGestureDelegate.iOS.cs
+++ b/src/View.Uno/Controls/SwipableItem/SwipableItemGestureDelegate.iOS.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 using UIKit;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
     internal class SwipableItemGestureDelegate: UIGestureRecognizerDelegate
 	{

--- a/src/View.Uno/Controls/SwipableItem/SwipableItemOutsideGestureDelegate.iOS.cs
+++ b/src/View.Uno/Controls/SwipableItem/SwipableItemOutsideGestureDelegate.iOS.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Text;
 using UIKit;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	internal class SwipableItemOutsideGestureDelegate : UIGestureRecognizerDelegate
 	{

--- a/src/View.Uno/Controls/SwipableItem/SwipingState.cs
+++ b/src/View.Uno/Controls/SwipableItem/SwipingState.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public enum SwipingState
 	{

--- a/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.Android.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.Android.cs
@@ -13,7 +13,7 @@ using AndroidX.Core.View;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class NativeSwipeRefresh : SwipeRefreshLayout, DependencyObject
 	{

--- a/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.iOS.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.iOS.cs
@@ -6,7 +6,7 @@ using CoreGraphics;
 using UIKit;
 using Windows.Foundation;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class NativeSwipeRefresh : UIRefreshControl
 	{

--- a/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.Android.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.Android.cs
@@ -12,7 +12,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class SwipeRefresh
 	{

--- a/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.UWP.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.UWP.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[TemplatePart(Name = ScrollViewerPartName, Type = typeof(ScrollViewer))]
 	[TemplatePart(Name = SnapPanelPartName, Type = typeof(SnapPanel))]

--- a/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// Control which implements the 'swipe to refresh' or 'pull to refresh' pattern. Shows a visual and calls a refresh trigger

--- a/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.iOS.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.iOS.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using Uno.Logging;
 using Uno.Disposables;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class SwipeRefresh
 	{

--- a/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.xaml
+++ b/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.xaml
@@ -1,11 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:local="using:Chinook.View.Controls"
+					xmlns:local="using:Nventive.View.Controls"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:xamarin="http://nventive.com/xamarin"
 					xmlns:ios="http://nventive.com/ios"
 					xmlns:android="http://nventive.com/android"
-					xmlns:u="using:Chinook.View.Controls"
+					xmlns:u="using:Nventive.View.Controls"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					mc:Ignorable="ios android xamarin">
 

--- a/src/View.Uno/Controls/ZoomControl/ResetViewPortZoomControlBehavior.cs
+++ b/src/View.Uno/Controls/ZoomControl/ResetViewPortZoomControlBehavior.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public static partial class ResetViewPortZoomControlBehavior
 	{

--- a/src/View.Uno/Controls/ZoomControl/ZoomControl.cs
+++ b/src/View.Uno/Controls/ZoomControl/ZoomControl.cs
@@ -25,7 +25,7 @@ using View = UIKit.UIView;
 using View = Android.Views.View;
 #endif
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// Represents a scrollable and zoomable area that can contain other visible elements.

--- a/src/View.Uno/Controls/ZoomControl/ZoomControl.xaml
+++ b/src/View.Uno/Controls/ZoomControl/ZoomControl.xaml
@@ -5,7 +5,7 @@
 					xmlns:xamarin="http://nventive.com/xamarin"
 					xmlns:ios="http://nventive.com/ios"
 					xmlns:android="http://nventive.com/android"
-					xmlns:u="using:Chinook.View.Controls"
+					xmlns:u="using:Nventive.View.Controls"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					mc:Ignorable="ios android xamarin">
 

--- a/src/View.Uno/Converters/ConverterBase.cs
+++ b/src/View.Uno/Converters/ConverterBase.cs
@@ -13,7 +13,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
     // We removed TargetType validation because of implicit conversion verification.  Since in some platforms
     // (not all), we can implicitely convert from one type to another either by using the implicit operators on

--- a/src/View.Uno/Converters/EnumToString/ConversionExtensionConverter.cs
+++ b/src/View.Uno/Converters/EnumToString/ConversionExtensionConverter.cs
@@ -16,7 +16,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter uses the conversion extensions that are registered in an application in order

--- a/src/View.Uno/Converters/EnumToString/FromEnumToStringConverter.cs
+++ b/src/View.Uno/Converters/EnumToString/FromEnumToStringConverter.cs
@@ -15,7 +15,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// Converts a enum value to a readable localizable string using the resource manager.

--- a/src/View.Uno/Converters/FromEmptyStringToCustomValueConverter.cs
+++ b/src/View.Uno/Converters/FromEmptyStringToCustomValueConverter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter outputs a custom value based on on the presence or absence of characters in a string.

--- a/src/View.Uno/Converters/FromEnumerableHasAnyToVisibilityConverter.cs
+++ b/src/View.Uno/Converters/FromEnumerableHasAnyToVisibilityConverter.cs
@@ -13,7 +13,7 @@ using Visibility = Windows.UI.Xaml.Visibility;
 using System.Windows;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter outputs a visibility value based on the presence of any items in an enumerable

--- a/src/View.Uno/Converters/FromInputScopeNameToInputScopeConverter.cs
+++ b/src/View.Uno/Converters/FromInputScopeNameToInputScopeConverter.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Input;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to turn an InputScopeNameValue into an InputScope

--- a/src/View.Uno/Converters/FromInputScopeNameValueToInputScopeConverter.cs
+++ b/src/View.Uno/Converters/FromInputScopeNameValueToInputScopeConverter.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using System.Text;
 using Windows.UI.Xaml.Input;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public class FromInputScopeNameValueToInputScopeConverter : ConverterBase
 	{

--- a/src/View.Uno/Converters/FromNullableBoolToCustomValueConverter.cs
+++ b/src/View.Uno/Converters/FromNullableBoolToCustomValueConverter.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml;
 using System.Windows;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to get a custom value if a nullable boolean is true or otherwise.

--- a/src/View.Uno/Converters/FromNullableBoolToReverseBoolConverter.cs
+++ b/src/View.Uno/Converters/FromNullableBoolToReverseBoolConverter.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter will return the opposite value of a nullable bool.

--- a/src/View.Uno/Converters/FromNullableBoolToVisibilityConverter.cs
+++ b/src/View.Uno/Converters/FromNullableBoolToVisibilityConverter.cs
@@ -12,7 +12,7 @@ using Visibility = Windows.UI.Xaml.Visibility;
 using System.Windows;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter will output a visibility based on if a nullable bool is set to true or otherwise.

--- a/src/View.Uno/Converters/FromNullableToCustomValueConverter.cs
+++ b/src/View.Uno/Converters/FromNullableToCustomValueConverter.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// A converter that is used to return a custom value based on the presence or absence of value.

--- a/src/View.Uno/Converters/FromNumericArithmeticToStringConverter.cs
+++ b/src/View.Uno/Converters/FromNumericArithmeticToStringConverter.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to format a numeric in a string after applying an arithmetic operation to it.

--- a/src/View.Uno/Converters/FromObjectToFormattedStringConverter.cs
+++ b/src/View.Uno/Converters/FromObjectToFormattedStringConverter.cs
@@ -16,7 +16,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// <para>A converter that applies a <seealso cref="String.Format(GenericCulture, object, object)"/> to a given object.</para>

--- a/src/View.Uno/Converters/FromOrientationToDefaultValueConverter.cs
+++ b/src/View.Uno/Converters/FromOrientationToDefaultValueConverter.cs
@@ -14,17 +14,13 @@ using System.Windows;
 using System.Windows.Controls;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter allows mapping an <seealso cref="Orientation"/> to any custom value.
 	/// </summary>
-	/// <remarks><para>Because an Orientation rarely (and shouldn't) comes from a view-model, this
-	/// converter doesn't support null values. If null comes in, null comes out.</para>
-	/// <para>This converter can be useful to customize a 
-	/// <see cref="nVentive.Chinook.Views.Controls.RichTextCoverPage">RichTextCoverPage</see> or 
-	/// <see cref="nVentive.Chinook.Views.Controls.RichTextOverflowPage">RichTextOverflowPage</see>, 
-	/// binding to the page's <see cref="nVentive.Chinook.Views.Controls.RichTextPage.Orientation">Orientation</see>.</para></remarks>
+	/// <remarks>Because an Orientation rarely (and shouldn't) comes from a view-model, this
+	/// converter doesn't support null values. If null comes in, null comes out.</remarks>
 	public class FromOrientationToDefaultValueConverter : ConverterBase
 	{
 		public object HorizontalValue { get; set; }

--- a/src/View.Uno/Converters/FromStringToCasedStringConverter.cs
+++ b/src/View.Uno/Converters/FromStringToCasedStringConverter.cs
@@ -16,7 +16,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// A converter that is used to change the character casing of a string.

--- a/src/View.Uno/Converters/MultiConverter.cs
+++ b/src/View.Uno/Converters/MultiConverter.cs
@@ -20,7 +20,7 @@ using System.Windows.Markup;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// A converter that chains multiple converters in order to provide a result.  Each provided will be 

--- a/src/View.Uno/Converters/NullConverter.cs
+++ b/src/View.Uno/Converters/NullConverter.cs
@@ -19,7 +19,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// A converter which always return null.

--- a/src/View.Uno/Converters/PartitionConverter/BoundMode.cs
+++ b/src/View.Uno/Converters/PartitionConverter/BoundMode.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public enum BoundMode
 	{

--- a/src/View.Uno/Converters/PartitionConverter/DiscretePartition.cs
+++ b/src/View.Uno/Converters/PartitionConverter/DiscretePartition.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	#region DiscretePartition
 	/// <summary>

--- a/src/View.Uno/Converters/PartitionConverter/DoubleEqualityAccuracy.cs
+++ b/src/View.Uno/Converters/PartitionConverter/DoubleEqualityAccuracy.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// 

--- a/src/View.Uno/Converters/PartitionConverter/DoubleEqualityAccuracyExtensions.cs
+++ b/src/View.Uno/Converters/PartitionConverter/DoubleEqualityAccuracyExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	internal static class DoubleEqualityAccuracyExtensions
 	{

--- a/src/View.Uno/Converters/PartitionConverter/IntervalPartition.cs
+++ b/src/View.Uno/Converters/PartitionConverter/IntervalPartition.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// Allows to match a value within a provided interval.

--- a/src/View.Uno/Converters/PartitionConverter/ParityPartitionStrategy.cs
+++ b/src/View.Uno/Converters/PartitionConverter/ParityPartitionStrategy.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// A partition strategy allowing to convert a numeric conversion value depending on its parity.

--- a/src/View.Uno/Converters/PartitionConverter/Partition.cs
+++ b/src/View.Uno/Converters/PartitionConverter/Partition.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// The base class of a partition set.

--- a/src/View.Uno/Converters/PartitionConverter/PartitionConverter.cs
+++ b/src/View.Uno/Converters/PartitionConverter/PartitionConverter.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Markup;
 using System.Windows.Markup;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is intended to partition the entire double universe in xaml.

--- a/src/View.Uno/Converters/PartitionConverter/PartitionStrategy.cs
+++ b/src/View.Uno/Converters/PartitionConverter/PartitionStrategy.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// An extensibility class allowing to create an user defined partition strategy over the double set.

--- a/src/View.Uno/Converters/PrettyDateConverter/FromDateToPrettyStringConverter.cs
+++ b/src/View.Uno/Converters/PrettyDateConverter/FromDateToPrettyStringConverter.cs
@@ -14,7 +14,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to provide an easily readable and comprehensible string based on a TimeSpan, DateTime or DateTimeOffset.

--- a/src/View.Uno/Converters/PrettyDateConverter/IAutoRefreshConverter.cs
+++ b/src/View.Uno/Converters/PrettyDateConverter/IAutoRefreshConverter.cs
@@ -12,7 +12,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public interface IAutoRefreshConverter : IValueConverter
 	{

--- a/src/View.Uno/Converters/PrettyDateConverter/PrettyDateFormatter.cs
+++ b/src/View.Uno/Converters/PrettyDateConverter/PrettyDateFormatter.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Chinook.View.Converters.PrettyDateConverter.Resources;
+using Nventive.View.Converters.PrettyDateConverter.Resources;
 #if !WINDOWS_UWP && !__ANDROID__ && !__IOS__ && !__WASM__
 using Uno.Localisation;
 #else
 using CultureInfo = System.String;
 #endif
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public interface IPrettyDateFormatter
 	{

--- a/src/View.Uno/Converters/PrettyDateConverter/Resources/PrettyDateFormatterStrings.Designer.cs
+++ b/src/View.Uno/Converters/PrettyDateConverter/Resources/PrettyDateFormatterStrings.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Chinook.View.Converters.PrettyDateConverter.Resources {
+namespace Nventive.View.Converters.PrettyDateConverter.Resources {
     using System;
     
     
@@ -19,7 +19,7 @@ namespace Chinook.View.Converters.PrettyDateConverter.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class PrettyDateFormatterStrings {
@@ -39,7 +39,7 @@ namespace Chinook.View.Converters.PrettyDateConverter.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Chinook.View.Converters.PrettyDateConverter.Resources.PrettyDateFormatterStrings" +
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nventive.View.Converters.PrettyDateConverter.Resources.PrettyDateFormatterStrings" +
                             "", typeof(PrettyDateFormatterStrings).Assembly);
                     resourceMan = temp;
                 }

--- a/src/View.Uno/Converters/PrettyDateConverter/Resources/PrettyDateFormatterStrings.UWP.cs
+++ b/src/View.Uno/Converters/PrettyDateConverter/Resources/PrettyDateFormatterStrings.UWP.cs
@@ -1,6 +1,6 @@
 ﻿#if WINDOWS_UWP
 #pragma warning disable CS0618 // Type or member is obsolete
-namespace Chinook.View.Converters.PrettyDateConverter.Resources
+namespace Nventive.View.Converters.PrettyDateConverter.Resources
 {
 	using System;
 	using System.Collections.Generic;
@@ -9,7 +9,7 @@ namespace Chinook.View.Converters.PrettyDateConverter.Resources
 
 	internal class PrettyDateFormatterStrings 
 	{
-		private const string ResourcePrefix = "Chinook.View/PrettyDateFormatterStrings/";
+		private const string ResourcePrefix = "Nventive.View/PrettyDateFormatterStrings/";
 
 		private static ResourceMap resourceMan;
 

--- a/src/View.Uno/Converters/PrettyDistanceConverter/DistanceHelper.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/DistanceHelper.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using Chinook.View.Converters.PrettyDistanceConverter.Resources;
+using Nventive.View.Converters.PrettyDistanceConverter.Resources;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public class DistanceHelper
 	{

--- a/src/View.Uno/Converters/PrettyDistanceConverter/DistanceUnit.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/DistanceUnit.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public enum DistanceUnit
 	{

--- a/src/View.Uno/Converters/PrettyDistanceConverter/DistanceUnitFormat.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/DistanceUnitFormat.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public enum DistanceUnitFormat
 	{

--- a/src/View.Uno/Converters/PrettyDistanceConverter/FromDistanceToPrettyStringConverter.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/FromDistanceToPrettyStringConverter.cs
@@ -16,7 +16,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to provide an easily readable and comprehensible string based on a distance.

--- a/src/View.Uno/Converters/PrettyDistanceConverter/PrettyDistanceFormatter.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/PrettyDistanceFormatter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public interface IPrettyDistanceFormatter
 	{

--- a/src/View.Uno/Converters/PrettyDistanceConverter/Resources/DistanceHelperStrings.Designer.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/Resources/DistanceHelperStrings.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Chinook.View.Converters.PrettyDistanceConverter.Resources {
+namespace Nventive.View.Converters.PrettyDistanceConverter.Resources {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace Chinook.View.Converters.PrettyDistanceConverter.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Chinook.View.Converters.PrettyDistanceConverter.Resources.DistanceHelperStrings", typeof(DistanceHelperStrings).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nventive.View.Converters.PrettyDistanceConverter.Resources.DistanceHelperStrings", typeof(DistanceHelperStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/View.Uno/Converters/PrettyDistanceConverter/Resources/DistanceHelperStrings.UWP.cs
+++ b/src/View.Uno/Converters/PrettyDistanceConverter/Resources/DistanceHelperStrings.UWP.cs
@@ -1,6 +1,6 @@
 ﻿#if WINDOWS_UWP
 #pragma warning disable CS0618 // Type or member is obsolete
-namespace Chinook.View.Converters.PrettyDistanceConverter.Resources
+namespace Nventive.View.Converters.PrettyDistanceConverter.Resources
 {
 	using System;
 	using System.Runtime.CompilerServices;
@@ -8,7 +8,7 @@ namespace Chinook.View.Converters.PrettyDistanceConverter.Resources
 
 	internal class DistanceHelperStrings
 	{
-		private const string ResourcePrefix = "Chinook.View/DistanceHelperStrings/";
+		private const string ResourcePrefix = "Nventive.View/DistanceHelperStrings/";
 
 		private static ResourceMap _resourceMap;
 

--- a/src/View.Uno/Converters/PrettySizeConverter/FromNumberToPrettyStringConverter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/FromNumberToPrettyStringConverter.cs
@@ -16,7 +16,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This is the base class for converters used for formatting double values to string.

--- a/src/View.Uno/Converters/PrettySizeConverter/FromQuantityToPrettyStringConverter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/FromQuantityToPrettyStringConverter.cs
@@ -16,7 +16,7 @@ using System.Windows.Data;
 using GenericCulture = System.Globalization.CultureInfo;
 #endif
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to provide an easily readable and comprehensible string based on a quantity.

--- a/src/View.Uno/Converters/PrettySizeConverter/FromSizeToPrettyStringConverter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/FromSizeToPrettyStringConverter.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Uno.Extensions;
 using Uno;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	/// <summary>
 	/// This converter is used to provide an easily readable and comprehensible string based on a file size.

--- a/src/View.Uno/Converters/PrettySizeConverter/IPrettyNumberFormatter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/IPrettyNumberFormatter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public interface IPrettyNumberFormatter
 	{

--- a/src/View.Uno/Converters/PrettySizeConverter/IPrettyQuantityFormatter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/IPrettyQuantityFormatter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public interface IPrettyQuantityFormatter : IPrettyNumberFormatter
 	{

--- a/src/View.Uno/Converters/PrettySizeConverter/IPrettySizeFormatter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/IPrettySizeFormatter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using Uno;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public interface IPrettySizeFormatter : IPrettyNumberFormatter
 	{

--- a/src/View.Uno/Converters/PrettySizeConverter/PrettyNumberFormatStep.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/PrettyNumberFormatStep.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public class PrettyNumberFormatStep
 	{

--- a/src/View.Uno/Converters/PrettySizeConverter/PrettyNumberFormatterBase.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/PrettyNumberFormatterBase.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public enum RoundingType
 	{

--- a/src/View.Uno/Converters/PrettySizeConverter/PrettyQuantityFormatter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/PrettyQuantityFormatter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public class PrettyQuantityFormatter : PrettyNumberFormatterBase, IPrettyQuantityFormatter
 	{

--- a/src/View.Uno/Converters/PrettySizeConverter/PrettySizeFormatter.cs
+++ b/src/View.Uno/Converters/PrettySizeConverter/PrettySizeFormatter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using Uno;
 
-namespace Chinook.View.Converters
+namespace Nventive.View.Converters
 {
 	public class PrettySizeFormatter : PrettyNumberFormatterBase, IPrettySizeFormatter
 	{

--- a/src/View.Uno/DataTemplateSelectors/TypesDataTemplateSelector.cs
+++ b/src/View.Uno/DataTemplateSelectors/TypesDataTemplateSelector.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using Uno;
 
-namespace Chinook.View.DataTemplateSelectors
+namespace Nventive.View.DataTemplateSelectors
 {
 	public class TypesDataTemplateSelector : DataTemplateSelector, IList<MatchType>
 	{

--- a/src/View.Uno/Extensions/BindableVisualState/BindableVisualState.cs
+++ b/src/View.Uno/Extensions/BindableVisualState/BindableVisualState.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// BindableVisualState is a class that exposes attachable properties named VisualStateName that lets you bind a string on a Control to set a VisualState.

--- a/src/View.Uno/Extensions/ComboBox/ComboBoxSynchronizerBehavior.cs
+++ b/src/View.Uno/Extensions/ComboBox/ComboBoxSynchronizerBehavior.cs
@@ -12,7 +12,7 @@ using SharedBinding = Windows.UI.Xaml.Data.Binding;
 using static Windows.UI.Xaml.DependencyObjectStore;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public static class ComboBoxSynchronizerBehavior
 	{

--- a/src/View.Uno/Extensions/ControlAutoFocus/ControlExtensions.AutoFocus.cs
+++ b/src/View.Uno/Extensions/ControlAutoFocus/ControlExtensions.AutoFocus.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class ControlExtensions
 	{

--- a/src/View.Uno/Extensions/ControlGotFocus/ControlExtensions.GotFocusBehavior.cs
+++ b/src/View.Uno/Extensions/ControlGotFocus/ControlExtensions.GotFocusBehavior.cs
@@ -8,7 +8,7 @@ using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class ControlExtensions
 	{

--- a/src/View.Uno/Extensions/ControlLostFocus/ControlExtensions.LostFocusBehavior.cs
+++ b/src/View.Uno/Extensions/ControlLostFocus/ControlExtensions.LostFocusBehavior.cs
@@ -8,7 +8,7 @@ using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class ControlExtensions
 	{

--- a/src/View.Uno/Extensions/ExpandIntoOverscroll/ExpandIntoOverscrollBehavior.cs
+++ b/src/View.Uno/Extensions/ExpandIntoOverscroll/ExpandIntoOverscrollBehavior.cs
@@ -13,7 +13,7 @@ using UIKit;
 using Uno.Extensions;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public class ExpandIntoOverscrollBehavior
 	{

--- a/src/View.Uno/Extensions/Hyperlink/HyperlinkExtensions.Command.cs
+++ b/src/View.Uno/Extensions/Hyperlink/HyperlinkExtensions.Command.cs
@@ -9,7 +9,7 @@ using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Documents;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class HyperlinkExtensions
 	{

--- a/src/View.Uno/Extensions/InputPane/InputPaneExtensions.PanIntoView.cs
+++ b/src/View.Uno/Extensions/InputPane/InputPaneExtensions.PanIntoView.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class InputPaneExtensions
 	{

--- a/src/View.Uno/Extensions/ListView/GroupedCollectionBehavior.cs
+++ b/src/View.Uno/Extensions/ListView/GroupedCollectionBehavior.cs
@@ -18,7 +18,7 @@ using _ListViewLegacy = Uno.UI.Controls.Legacy.ListView;
 using _ListViewBase = Windows.UI.Xaml.Controls.ListViewBase;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// Wraps a IGrouping<TKey, TValue> into a CollectionViewSource with IsSourceGrouped enabled. Can be used with IEnumerable.GroupBy or GroupAlphabetically.

--- a/src/View.Uno/Extensions/ListView/ListViewBaseExtensions.BringSelectedItemIntoView.cs
+++ b/src/View.Uno/Extensions/ListView/ListViewBaseExtensions.BringSelectedItemIntoView.cs
@@ -9,7 +9,7 @@ using IDependencyObject = Windows.UI.Xaml.DependencyObject;
 #endif
 
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// A behavior that, when attached to a listView, scrolls SelectedItem into view when it is selected.

--- a/src/View.Uno/Extensions/ListView/ListViewBaseExtensions.Command.cs
+++ b/src/View.Uno/Extensions/ListView/ListViewBaseExtensions.Command.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Controls;
 using System.Runtime.CompilerServices;
 using Uno.Logging;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// Contains attached properties that can be applied to a <see cref="ListViewBase"/> to work with commands.

--- a/src/View.Uno/Extensions/ListView/ListViewBaseMultiColumnExtension.cs
+++ b/src/View.Uno/Extensions/ListView/ListViewBaseMultiColumnExtension.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// Extension that allows to update the listview template's size when the size of the screen changes,

--- a/src/View.Uno/Extensions/ListView/ListViewBaseMultipleSelectionBehavior.cs
+++ b/src/View.Uno/Extensions/ListView/ListViewBaseMultipleSelectionBehavior.cs
@@ -9,7 +9,7 @@ using Uno.Logging;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// Behavior that allows values to be bound to the SelectedItems property of a ListViewBase control

--- a/src/View.Uno/Extensions/MultipleTap/MultipleTapExtension.cs
+++ b/src/View.Uno/Extensions/MultipleTap/MultipleTapExtension.cs
@@ -7,7 +7,7 @@ using Uno.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public class MultipleTapExtension
 	{

--- a/src/View.Uno/Extensions/Page/PageBehavior.cs
+++ b/src/View.Uno/Extensions/Page/PageBehavior.cs
@@ -7,7 +7,7 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// Provides attached properties on UserControl or Page to handle StatusBar

--- a/src/View.Uno/Extensions/PasswordBox/PasswordBoxBehavior.UWP.cs
+++ b/src/View.Uno/Extensions/PasswordBox/PasswordBoxBehavior.UWP.cs
@@ -13,7 +13,7 @@ using Uno.Disposables;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class PasswordBoxBehavior : DependencyObject
 	{

--- a/src/View.Uno/Extensions/PasswordBox/PasswordBoxBehavior.cs
+++ b/src/View.Uno/Extensions/PasswordBox/PasswordBoxBehavior.cs
@@ -12,7 +12,7 @@ using Windows.System;
 using System.Reactive.Linq;
 using System.Reactive.Concurrency;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	[Windows.UI.Xaml.Data.Bindable]
 	public partial class PasswordBoxBehavior
@@ -110,7 +110,7 @@ namespace Chinook.View.Extensions
 		/// <param name="e">Dependency property event arguments</param>
 		private static void EnterCommandChanged(object d, DependencyPropertyChangedEventArgs e)
 		{
-			//For Windows the event is hooked up in Chinook.Views.Shared.Xaml.PasswordBehavior.cs
+			//For Windows the event is hooked up in Nventive.Views.Shared.Xaml.PasswordBehavior.cs
 #if __ANDROID__ || __IOS__
 			var box = d as PasswordBox;
 			if (box != null && e.NewValue != null)

--- a/src/View.Uno/Extensions/PasswordBox/PasswordEnterCommand.Xamarin.cs
+++ b/src/View.Uno/Extensions/PasswordBox/PasswordEnterCommand.Xamarin.cs
@@ -22,7 +22,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.System;
 #endif
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public class PasswordEnterCommand
 	{

--- a/src/View.Uno/Extensions/Rect/RectExtensions.cs
+++ b/src/View.Uno/Extensions/Rect/RectExtensions.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Graphics.Display;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	internal static class RectExtensions
 	{

--- a/src/View.Uno/Extensions/ScrollViewer/ScrollViewerExtensions.ScrollIndicatorStyle.cs
+++ b/src/View.Uno/Extensions/ScrollViewer/ScrollViewerExtensions.ScrollIndicatorStyle.cs
@@ -12,7 +12,7 @@ using Uno.Logging;
 using UIKit;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// Allows for setting the UIScrollViewIndicatorStyle of a ScrollViewer on iOS. Does not apply to other platforms

--- a/src/View.Uno/Extensions/ScrollViewer/ScrollViewerExtensions.UWP.cs
+++ b/src/View.Uno/Extensions/ScrollViewer/ScrollViewerExtensions.UWP.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	static public partial class ScrollViewerExtensions
 	{

--- a/src/View.Uno/Extensions/SplitView/SplitViewBehavior.cs
+++ b/src/View.Uno/Extensions/SplitView/SplitViewBehavior.cs
@@ -17,7 +17,7 @@ using Uno.UI;
 using Uno.UI.Controls;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// This behavior adds features to the SplitView.

--- a/src/View.Uno/Extensions/SplitView/SplitViewExtensions.cs
+++ b/src/View.Uno/Extensions/SplitView/SplitViewExtensions.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 #if __IOS__
 	[Foundation.PreserveAttribute(AllMembers = true)]

--- a/src/View.Uno/Extensions/StickyGroupHeader/StickyGroupHeaderBehavior.cs
+++ b/src/View.Uno/Extensions/StickyGroupHeader/StickyGroupHeaderBehavior.cs
@@ -15,7 +15,7 @@ using _FrameworkElement = Windows.UI.Xaml.FrameworkElement;
 using _FrameworkElement = Windows.UI.Xaml.FrameworkElement;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public static class StickyGroupHeaderBehavior
 	{

--- a/src/View.Uno/Extensions/TextBlock/HtmlTextBlockBehavior.Properties.cs
+++ b/src/View.Uno/Extensions/TextBlock/HtmlTextBlockBehavior.Properties.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class HtmlTextBlockBehavior
 	{

--- a/src/View.Uno/Extensions/TextBlock/HtmlTextBlockBehavior.cs
+++ b/src/View.Uno/Extensions/TextBlock/HtmlTextBlockBehavior.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class HtmlTextBlockBehavior
 	{

--- a/src/View.Uno/Extensions/TextBlock/TextBlockBehavior.cs
+++ b/src/View.Uno/Extensions/TextBlock/TextBlockBehavior.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public class TextBlockBehavior
 	{

--- a/src/View.Uno/Extensions/TextBox/InputAccessoryViewBehavior.iOS.cs
+++ b/src/View.Uno/Extensions/TextBox/InputAccessoryViewBehavior.iOS.cs
@@ -9,7 +9,7 @@ using CoreGraphics;
 using Uno.Extensions;
 using UIKit;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	/// <summary>
 	/// This behavior adds an extendion on top of the keyboard for iOS. Each TextBox must be identified by a separate ID (string) in order for this behavior to work as intended.

--- a/src/View.Uno/Extensions/TextBox/TextBoxBehavior.UWP.cs
+++ b/src/View.Uno/Extensions/TextBox/TextBoxBehavior.UWP.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Globalization;
 using Uno.Disposables;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public partial class TextBoxBehavior : DependencyObject
 	{

--- a/src/View.Uno/Extensions/TextBox/TextBoxBehavior.Xamarin.cs
+++ b/src/View.Uno/Extensions/TextBox/TextBoxBehavior.Xamarin.cs
@@ -8,7 +8,7 @@ using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
     public partial class TextBoxBehavior
     {

--- a/src/View.Uno/Extensions/TextBox/TextBoxBehavior.cs
+++ b/src/View.Uno/Extensions/TextBox/TextBoxBehavior.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	[Windows.UI.Xaml.Data.Bindable]
 	public partial class TextBoxBehavior

--- a/src/View.Uno/Extensions/TextBox/TextBoxExtensions.AutoUpdateBindingDelay.cs
+++ b/src/View.Uno/Extensions/TextBox/TextBoxExtensions.AutoUpdateBindingDelay.cs
@@ -8,7 +8,7 @@ using Uno.Extensions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Extensions
+namespace Nventive.View.Extensions
 {
 	public class TextBoxExtendedProperties
 	{

--- a/src/View.Uno/Internal/ActionDisposable.cs
+++ b/src/View.Uno/Internal/ActionDisposable.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal class ActionDisposable : IDisposable
 	{

--- a/src/View.Uno/Internal/DependencyObjectExtensions.cs
+++ b/src/View.Uno/Internal/DependencyObjectExtensions.cs
@@ -27,7 +27,7 @@ using UIKit;
 #endif
 
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal static partial class DependencyObjectExtensions
 	{

--- a/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.Android.cs
+++ b/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.Android.cs
@@ -4,7 +4,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using Android.OS;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal partial class MainDispatcherScheduler
 	{

--- a/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.UWP.cs
+++ b/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.UWP.cs
@@ -5,7 +5,7 @@ using System.Reactive.Concurrency;
 using System.Text;
 using Windows.UI.Core;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal partial class MainDispatcherScheduler : IScheduler
 	{

--- a/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.WASM.cs
+++ b/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.WASM.cs
@@ -3,7 +3,7 @@ using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal partial class MainDispatcherScheduler
 	{

--- a/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.cs
+++ b/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.cs
@@ -4,7 +4,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using Windows.UI.Core;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal partial class MainDispatcherScheduler : IScheduler
 	{

--- a/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.iOS.cs
+++ b/src/View.Uno/Internal/MainDispatcher/MainDispatcherScheduler.iOS.cs
@@ -4,7 +4,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using Foundation;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal partial class MainDispatcherScheduler
 	{

--- a/src/View.Uno/Internal/ObservableExtensions.cs
+++ b/src/View.Uno/Internal/ObservableExtensions.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml;
 using FrameworkElement = Windows.UI.Xaml.FrameworkElement;
 #endif
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	[Flags]
 	internal enum SubscribeToElementOptions : byte

--- a/src/View.Uno/Internal/PropertyMetadataHelper.cs
+++ b/src/View.Uno/Internal/PropertyMetadataHelper.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal class PropertyMetadataHelper
 	{

--- a/src/View.Uno/Internal/SizeExtensions.cs
+++ b/src/View.Uno/Internal/SizeExtensions.cs
@@ -7,7 +7,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
 using NativeValue = System.Double;
 
-namespace Chinook.View
+namespace Nventive.View
 {
 	internal static class SizeExtensions
 	{

--- a/src/View.Uno/Panels/LandscapeUprightPanel/LandscapeUprightPanel.UWP.cs
+++ b/src/View.Uno/Panels/LandscapeUprightPanel/LandscapeUprightPanel.UWP.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Controls;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
     public partial class LandscapeUprightPanel : Grid
     {

--- a/src/View.Uno/Panels/LandscapeUprightPanel/LandscapeUprightPanel.cs
+++ b/src/View.Uno/Panels/LandscapeUprightPanel/LandscapeUprightPanel.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// Arranges and rotates child elements to ensure that when they are displayed in Landscape, they are always displayed

--- a/src/View.Uno/Panels/ProportionalPanel/ProportionalPanel.cs
+++ b/src/View.Uno/Panels/ProportionalPanel/ProportionalPanel.cs
@@ -7,7 +7,7 @@ using Uno.Extensions;
 using Uno.Logging;
 using System.ComponentModel;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	/// <summary>
 	/// A custom panel which maintains proportion on the child controls.

--- a/src/View.Uno/Panels/SnapPanel/SnapAnchor.cs
+++ b/src/View.Uno/Panels/SnapPanel/SnapAnchor.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	[Flags]
 	public enum SnapAnchor

--- a/src/View.Uno/Panels/SnapPanel/SnapPanel.cs
+++ b/src/View.Uno/Panels/SnapPanel/SnapPanel.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public class SnapPanel : Panel, IScrollSnapPointsInfo
 	{

--- a/src/View.Uno/Panels/SnapPanel/SnapPoint.cs
+++ b/src/View.Uno/Panels/SnapPanel/SnapPoint.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public class SnapPoint
 	{

--- a/src/View.Uno/Panels/SnapPanel/SnapPointInfo.cs
+++ b/src/View.Uno/Panels/SnapPanel/SnapPointInfo.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public class SnapPointInfo
 	{

--- a/src/View.Uno/Panels/StarStackPanel/StarStackPanel.cs
+++ b/src/View.Uno/Panels/StarStackPanel/StarStackPanel.cs
@@ -21,7 +21,7 @@ using UIElement = Android.Views.View;
 using UIElement = UIKit.UIView;
 #endif
 
-namespace Chinook.View.Controls
+namespace Nventive.View.Controls
 {
 	public partial class StarStackPanel : Panel
 	{

--- a/src/View.Uno/Themes/Generic.xaml
+++ b/src/View.Uno/Themes/Generic.xaml
@@ -1,16 +1,16 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<ResourceDictionary.MergedDictionaries>
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/DelayControl/DelayControl.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/ImagePresenter/ImagePresenter.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/ImageSlideshow/ImageSlideshow.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/LogCounterControl/LogCounterControl.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/MembershipCardControl/MembershipCardControl.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/PathControl/PathControl.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/ParallaxListView/ParallaxListView.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/PeekingFlipView/PeekingFlipView.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/PeekingFlipView/PeekingFlipViewItem.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/SwipeRefresh/SwipeRefresh.xaml" />
-		<ResourceDictionary Source="ms-appx:///Chinook.View.Uno/Controls/ZoomControl/ZoomControl.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/DelayControl/DelayControl.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/ImagePresenter/ImagePresenter.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/ImageSlideshow/ImageSlideshow.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/LogCounterControl/LogCounterControl.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/MembershipCardControl/MembershipCardControl.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/PathControl/PathControl.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/ParallaxListView/ParallaxListView.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/PeekingFlipView/PeekingFlipView.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/PeekingFlipView/PeekingFlipViewItem.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/SwipeRefresh/SwipeRefresh.xaml" />
+		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/ZoomControl/ZoomControl.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/View.Uno/View.Uno.csproj
+++ b/src/View.Uno/View.Uno.csproj
@@ -5,12 +5,12 @@
 		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;uap10.0.17763</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
-		<RootNamespace>Chinook.View</RootNamespace>
+		<RootNamespace>Nventive.View</RootNamespace>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
-		<AssemblyName>Chinook.View.Uno</AssemblyName>
-		<PackageId>Chinook.View.Uno</PackageId>
-		<Description>Chinook.View.Uno</Description>
+		<AssemblyName>Nventive.View.Uno</AssemblyName>
+		<PackageId>Nventive.View.Uno</PackageId>
+		<Description>Nventive.View.Uno</Description>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -67,6 +67,12 @@
 		<None Include="**\*.UWP.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
+	  <Compile Update="Converters\PrettyDateConverter\Resources\PrettyDateFormatterStrings.Designer.cs">
+	    <DesignTime>True</DesignTime>
+	  </Compile>
+	  <Compile Update="Converters\PrettyDistanceConverter\Resources\DistanceHelperStrings.Designer.cs">
+	    <DesignTime>True</DesignTime>
+	  </Compile>
 	  <Compile Update="Panels\SnapPanel\SnapAnchor.cs">
 	    <Generator>MSBuild:Compile</Generator>
 	  </Compile>


### PR DESCRIPTION
## Proposed Changes

Refactoring (no functional changes, no api changes) 


## What is the current behavior?

- Chinook namespaces and assembly/package name

## What is the new behavior?

- Removed Chinook naming by Nventive 


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

