### PR TITLE
Bump to Uno.UI 4.0 

### DIFF
--- a/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.Android.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.Android.cs
@@ -15,7 +15,7 @@ using AndroidX.RecyclerView.Widget;
 
 namespace Nventive.View.Controls
 {
-	public partial class NativeSwipeRefresh : SwipeRefreshLayout, DependencyObject
+	public partial class NativeSwipeRefresh : SwipeRefreshLayout
 	{
 		public NativeSwipeRefresh() : base(ContextHelper.Current) { }
 

--- a/src/View.Uno/Panels/StarStackPanel/StarStackPanel.cs
+++ b/src/View.Uno/Panels/StarStackPanel/StarStackPanel.cs
@@ -633,7 +633,6 @@ namespace Nventive.View.Controls
 		}
 		#endregion
 
-#if !__ANDROID__ && !__IOS__ && !__WASM__ //In Uno, Padding is (incorrectly) defined on Panel
 		#region Padding DependencyProperty
 
 		public Thickness Padding
@@ -647,7 +646,6 @@ namespace Nventive.View.Controls
 			DependencyProperty.Register("Padding", typeof(Thickness), typeof(StarStackPanel), new PropertyMetadata(default(Thickness), InvalidateLayoutOnChanged));
 
 		#endregion
-#endif
 
 		#region struct Record
 		private struct Record

--- a/src/View.Uno/View.Uno.csproj
+++ b/src/View.Uno/View.Uno.csproj
@@ -19,8 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="3.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
+    <PackageReference Include="Uno.UI" Version="4.0.7" />
+    <PackageReference Include="Uno.Core" Version="4.1.0-dev.2" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
 		<PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Proposed Changes

-  Bumped dependencies for **Uno.UI 4.0** 


## What is the current behavior?

- When using this library in a project that targets Uno.UI 4.0, there is an error thrown due to the latest dispatcher changes. 


## What is the new behavior?

- Bumping to Uno.UI 4 fixes the issue. 


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

