### PR TITLE
feat: Target Android 12 and build on VS2022

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,20 +7,20 @@ trigger:
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
-  value: 5.8.1
+  value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.8.6
+  value: 17.1.1
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
   value: View.sln
 # Pool names
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.3.0
+next-version: 0.4.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/doc/_DevelopmentTips.md
+++ b/doc/_DevelopmentTips.md
@@ -9,9 +9,9 @@ This means that each project is compiled to generate one assembly per target.
 The available targets are:
 - Windows (UWP)
 - iOS
-- Android 8.0
-- Android 9.0
-- Net461
+- Android 11.0
+- Android 12.0
+- net472
 - WebAssembly (WASM)
 
 Compiling all targets can take some time.

--- a/doc/_ReleaseNotes.md
+++ b/doc/_ReleaseNotes.md
@@ -2,12 +2,17 @@
 
 ## Next Version 
 ### Features
+* Build with VS2022
+* Add support for uap10.0.19041
+* Add support for Android 12
 * Added new properties `OpenUriCommand`, `HyperlinkUnderlineStyle` and `HyperlinkDefaultFontWeight` in `HtmlTextBlockBehavior`.
 * Add support for Android 10
 * Add support for Android X
 * Update xamarin build download to 0.10.0 to add subdependencies bug fix
 * 
 ### Breaking changes 
+* Dropped support for uap10.0.18362
+* Dropped support for MonoAndroid10 target
 * updated CommonServiceLocator to 2.0.5
 * Dropped support for MonoAndroid80 target
 * Updated to Uno.UI 3.0+

--- a/src/View.Uno/View.Uno.csproj
+++ b/src/View.Uno/View.Uno.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<RootNamespace>Nventive.View</RootNamespace>
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
 	<!-- UWP -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.18362'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.19041'">
 		<!-- Include all .XAML files. -->
 		<Page Include="Controls\**\*.xaml">
 			<Pack>True</Pack>
@@ -55,13 +55,13 @@
 
 		<PRIResource Include="**\*.resw" />
 
-		<SDKReference Include="WindowsMobile, Version=10.0.18362.0">
+		<SDKReference Include="WindowsMobile, Version=10.0.19041.0">
 			<Name>Microsoft Mobile Extension SDK for Universal App Platform</Name>
 		</SDKReference>
 	</ItemGroup>
 
 	<!-- Uno -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'xamarinios10' or '$(TargetFramework)' == 'MonoAndroid10.0' or '$(TargetFramework)' == 'MonoAndroid11.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'xamarinios10' or '$(TargetFramework)' == 'MonoAndroid11.0' or '$(TargetFramework)' == 'MonoAndroid12.0'">
 		<!-- Include all .XAML files. -->
 		<Page Include="Controls\**\*.xaml" />
 


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes
Support Android 12 and build on VS2022

Feature
Build or CI related changes
Documentation content changes


## What is the current behavior?
Does not support Android 12 and build on VS2022


## What is the new behavior?
Supports Android 12 and build on VS2022


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

Since all new projects will need to target Android 12, it is not needed to target Android 10 anymore


## Other information

