### PR TITLE
fix: Remove last ref to ImagePresenter

### DIFF
--- a/src/View.Uno/Themes/Generic.xaml
+++ b/src/View.Uno/Themes/Generic.xaml
@@ -2,7 +2,6 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/DelayControl/DelayControl.xaml" />
-		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/ImagePresenter/ImagePresenter.xaml" />
 		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/ImageSlideshow/ImageSlideshow.xaml" />
 		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/LogCounterControl/LogCounterControl.xaml" />
 		<ResourceDictionary Source="ms-appx:///Nventive.View.Uno/Controls/MembershipCardControl/MembershipCardControl.xaml" />


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes

Bug fix


## What is the current behavior?
ImagePresenter was deleted and there was still a reference to it


## What is the new behavior?
No reference to ImagePresenter


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue


## Other information

