### PR TITLE
fix: Restore proper pointer state by setting Handled=true in Multiple…

### DIFF
--- a/src/View.Uno/Extensions/MultipleTap/MultipleTapExtension.cs
+++ b/src/View.Uno/Extensions/MultipleTap/MultipleTapExtension.cs
@@ -81,6 +81,8 @@ namespace Nventive.View.Extensions
 		
 		private static void ExecuteCommand(object sender, PointerRoutedEventArgs args)
 		{
+			args.Handled = true;
+
 			var dependencyObject = sender as DependencyObject;
 
 			var command = GetCommand(dependencyObject);


### PR DESCRIPTION
…TapExtension.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

`PointerRoutedEventArgs.Handled` is not set to `true `in `MultipleTapExtension`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

`PointerRoutedEventArgs.Handled` is set to `true `in `MultipleTapExtension`.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

Linked to https://github.com/unoplatform/uno/issues/9512