### PR TITLE
fix: Android SwipeRefresh DataContext propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,5 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
+* Fix issue #35: DataContext propagation on Android
 
 ### Security

--- a/doc/SwipeRefresh.md
+++ b/doc/SwipeRefresh.md
@@ -104,4 +104,13 @@ By default, `IncludeInSwipeRefresh` is set to `True`. Setting it to `False` will
 
 ## Known issues
 
-None.
+On Android, bindings on the DataContext on the first child of the SwipeRefresh will be ignored, such as:
+
+```xml
+<u:SwipeRefresh>
+	<!--This binding is ignored-->
+	<Grid DataContext="{Binding MyString}">
+	...
+	</Grid>
+</u:SwipeRefresh>
+```

--- a/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.Android.cs
+++ b/src/View.Uno/Controls/SwipeRefresh/SwipeRefresh.Android.cs
@@ -8,6 +8,7 @@ using Android.Widget;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.UI;
+using Uno.UI.Controls;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
@@ -79,6 +80,21 @@ namespace Nventive.View.Controls
 			if (_nativeSwipeRefresh != null)
 			{
 				_nativeSwipeRefresh.Content = Content as Android.Views.View;
+			}
+
+			if (Content is BindableView bv)
+			{
+				bv.DataContext = DataContext;
+			}
+		}
+
+		protected override void OnDataContextChanged()
+		{
+			base.OnDataContextChanged();
+
+			if (Content is BindableView bv)
+			{
+				bv.DataContext = DataContext;
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->
https://github.com/nventive/Nventive.View/issues/35

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

The DataContext is not propagated from SwipeRefresh to its Content.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The DataContext is correctly propagated from SwipeRefresh to its Content - other than in a specific case where the DataContext is explicitly set by the first child of SwipeRefresh (see the readme update)

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [x] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

