### PR TITLE
fix: Use the correct dispatcher in PasswordBoxBehavior for WinUI

### DIFF
--- a/src/View.Uno.Sample/View.Uno.Sample.Shared/MainPage.xaml
+++ b/src/View.Uno.Sample/View.Uno.Sample.Shared/MainPage.xaml
@@ -5,6 +5,7 @@
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:nvc="using:Nventive.View.Controls"
+	  xmlns:ext="using:Nventive.View.Extensions"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -19,25 +20,12 @@
 					Height="48" />
 
 		<ScrollViewer Grid.Row="1">
-			<StackPanel Margin="16"
-						Spacing="16">
+			<StackPanel>
+				<PasswordBox ext:PasswordBoxBehavior.NextControl="{Binding ElementName=TextBox}"
+							 Password="hello" />
 
-				<!-- Playground. -->
-
-				<!-- DelayControl -->
-				<TextBlock Text="Delay Control: Appears 2 seconds after loading." />
-				<nvc:DelayControl DelayAfterLoad="00:00:02.00"
-								  DelayAfterDataContext="00:00:00.00"
-								  Height="48"
-								  Width="48"
-								  WaitForInnerView="False">
-
-					<DataTemplate>
-						<Ellipse Fill="Red"
-								 HorizontalAlignment="Stretch"
-								 VerticalAlignment="Stretch" />
-					</DataTemplate>
-				</nvc:DelayControl>
+				<TextBox Text="next"
+						 x:Name="TextBox" />
 			</StackPanel>
 		</ScrollViewer>
 	</Grid>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
Bug fix

## What is the current behavior?
On WinUI, using PasswordBoxBehavior results in an incorrect cast exception when attempting to retrieve the dispatcher scheduler.


## What is the new behavior?
On WinUI, using PasswordBoxBehavior results in correct behavior and no exception.


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

